### PR TITLE
build: remove lint step from push-master workflow

### DIFF
--- a/.github/workflows/push-master.yaml
+++ b/.github/workflows/push-master.yaml
@@ -21,7 +21,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: "https://registry.npmjs.org"
       - run: yarn install
-      - run: yarn lint
       - run: yarn build
       - run: yarn test
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc 2> /dev/null


### PR DESCRIPTION
## Description

Tweaks push master work flow to not run linting as it is not configured yet

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)