### PR TITLE
build: fix link to publish unstable script

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:node": "yarn jest",
     "test:browser": "./scripts/test-browser.sh",
     "benchmark:node": "ts-node ./bench/index.ts",
-    "publish:unstable": "./scripts/publish_unstable.sh",
+    "publish:unstable": "./scripts/publish-unstable.sh",
     "publish:release": "./scripts/publish.sh",
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md",
     "version:release": "yarn version --minor --message \"chore(release): publish [skip ci]\""


### PR DESCRIPTION
## Description

Fixes the link to the publish unstable script

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

CD of unstable package releases

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)