### PR TITLE
build: add support for removing post install script

### DIFF
--- a/scripts/publish-unstable.sh
+++ b/scripts/publish-unstable.sh
@@ -9,6 +9,9 @@
 # Add dev dependencies to current path
 export PATH="$PATH:node_modules/.bin"
 
+# Remove the post install script from the package.json
+node scripts/remove-install-script.js
+
 # Minor version the current package
 yarn version --no-git-tag-version --patch
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -9,6 +9,9 @@
 # Add dev dependencies to current path
 export PATH="$PATH:node_modules/.bin"
 
+# Remove the post install script from the package.json
+node scripts/remove-install-script.js
+
 # Fetch the current version from the package.json
 new_version=$(node -pe "require('./package.json').version")
 

--- a/scripts/remove-install-script.js
+++ b/scripts/remove-install-script.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const fs = require("fs");
+let packageJson = require("../package.json");
+
+// Remove the post install script
+delete packageJson.scripts.install;
+
+fs.writeFileSync("package.json", JSON.stringify(packageJson, null, 2));


### PR DESCRIPTION
## Description

Adds support for removing post install script during release process

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)