### PR TITLE
fix: uint8array return type casting

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -19,9 +19,22 @@ module.exports.DEFAULT_BLS12381_PUBLIC_KEY_LENGTH = 96;
 
 module.exports.BBS_SIGNATURE_LENGTH = 112;
 
-module.exports.generateBls12381KeyPair = wasm.generateBls12381KeyPair;
+module.exports.generateBls12381KeyPair = (seed) => {
+  var result = wasm.generateBls12381KeyPair(seed);
+  return {
+    secretKey: result.secretKey ? new Uint8Array(result.secretKey) : undefined,
+    publicKey: new Uint8Array(result.publicKey),
+  };
+};
 
-module.exports.bls12381toBbs = wasm.bls12381toBbs;
+module.exports.bls12381toBbs = (request) => {
+  var result = wasm.bls12381toBbs(request);
+  return {
+    publicKey: new Uint8Array(result.publicKey),
+    secretKey: result.secretKey ? new Uint8Array(result.secretKey) : undefined,
+    messageCount: result.messageCount,
+  };
+};
 
 module.exports.Bls12381ToBbsRequest = wasm.Bls12381ToBbsRequest;
 

--- a/tests/bbsSignature/createProof.bbsSignature.spec.ts
+++ b/tests/bbsSignature/createProof.bbsSignature.spec.ts
@@ -45,6 +45,7 @@ describe("bbsSignature", () => {
       };
 
       const proof = createProof(request);
+      expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(383);
     });
 
@@ -71,6 +72,7 @@ describe("bbsSignature", () => {
       };
 
       const proof = createProof(request);
+      expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(383);
     });
 
@@ -97,6 +99,7 @@ describe("bbsSignature", () => {
       };
 
       const proof = createProof(request);
+      expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(447);
     });
 
@@ -123,6 +126,7 @@ describe("bbsSignature", () => {
       };
 
       const proof = createProof(request);
+      expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(415);
     });
   });
@@ -146,6 +150,7 @@ describe("bbsSignature", () => {
       };
 
       const proof = blsCreateProof(request);
+      expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(383);
     });
 
@@ -172,6 +177,7 @@ describe("bbsSignature", () => {
       };
 
       const proof = blsCreateProof(request);
+      expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(383); //TODO add a reason for this and some constants?
     });
 
@@ -198,6 +204,7 @@ describe("bbsSignature", () => {
       };
 
       const proof = blsCreateProof(request);
+      expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(447); //TODO add a reason for this and some constants?
     });
 
@@ -224,6 +231,7 @@ describe("bbsSignature", () => {
       };
 
       const proof = blsCreateProof(request);
+      expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(415); //TODO evaluate this length properly add a reason for this and some constants?
     });
   });

--- a/tests/bbsSignature/sign.bbsSignature.spec.ts
+++ b/tests/bbsSignature/sign.bbsSignature.spec.ts
@@ -42,6 +42,7 @@ describe("bbsSignature", () => {
         messages: ["ExampleMessage"],
       };
       const signature = sign(request);
+      expect(signature).toBeInstanceOf(Uint8Array);
       expect(signature.length).toEqual(BBS_SIGNATURE_LENGTH);
     });
 
@@ -51,6 +52,7 @@ describe("bbsSignature", () => {
         messages: ["ExampleMessage", "ExampleMessage2", "ExampleMessage3"],
       };
       const signature = sign(request);
+      expect(signature).toBeInstanceOf(Uint8Array);
       expect(signature.length).toEqual(BBS_SIGNATURE_LENGTH);
     });
 
@@ -60,6 +62,7 @@ describe("bbsSignature", () => {
         messages: ["ExampleMessage", "ExampleMessage"],
       };
       const signature = sign(request);
+      expect(signature).toBeInstanceOf(Uint8Array);
       expect(signature.length).toEqual(BBS_SIGNATURE_LENGTH);
     });
 
@@ -95,6 +98,7 @@ describe("bbsSignature", () => {
         messages: ["ExampleMessage"],
       };
       const signature = blsSign(request);
+      expect(signature).toBeInstanceOf(Uint8Array);
       expect(signature.length).toEqual(BBS_SIGNATURE_LENGTH);
     });
 
@@ -104,6 +108,7 @@ describe("bbsSignature", () => {
         messages: ["ExampleMessage", "ExampleMessage2", "ExampleMessage3"],
       };
       const signature = blsSign(request);
+      expect(signature).toBeInstanceOf(Uint8Array);
       expect(signature.length).toEqual(BBS_SIGNATURE_LENGTH);
     });
 

--- a/tests/bls12381.spec.ts
+++ b/tests/bls12381.spec.ts
@@ -50,8 +50,10 @@ describe("bls12381", () => {
         "base64"
       )
     );
-    expect(new Buffer(result.secretKey as Uint8Array)).toEqual(
-      new Buffer("YoASulEi3WV7yfJ+yWctJRCbHfr7WjK7JjcMrRqbL6E=", "base64")
+    expect(result.secretKey as Uint8Array).toEqual(
+      new Uint8Array(
+        new Buffer("YoASulEi3WV7yfJ+yWctJRCbHfr7WjK7JjcMrRqbL6E=", "base64")
+      )
     );
   });
 });

--- a/tests/bls12381ToBbs.spec.ts
+++ b/tests/bls12381ToBbs.spec.ts
@@ -25,6 +25,8 @@ describe("bls12381toBbs", () => {
     expect(bbsKeyPair.messageCount).toEqual(10);
     expect(bbsKeyPair.secretKey).toBeDefined();
     expect(bbsKeyPair.publicKey).toBeDefined();
+    expect(bbsKeyPair.publicKey).toBeInstanceOf(Uint8Array);
+    expect(bbsKeyPair.secretKey).toBeInstanceOf(Uint8Array);
   });
 
   it("should be able to convert bls12381 public key to bbs key", () => {
@@ -42,6 +44,7 @@ describe("bls12381toBbs", () => {
     expect(bbsKeyPair.messageCount).toEqual(10);
     expect(bbsKeyPair.secretKey).toBeUndefined();
     expect(bbsKeyPair.publicKey).toBeDefined();
+    expect(bbsKeyPair.publicKey).toBeInstanceOf(Uint8Array);
   });
 
   it("should throw error when message count 0", () => {


### PR DESCRIPTION
## Description

This PR fixes an issue that was occurring when a byte array (Vec<u8>) was being returned inside a JS struct, which should map to the instantiation of a Uint8Array in JS however it was only being interpreted as an ordinary array with numerical elements.

This PR catches the results from the relevant API calls and explicitly instantiates an element to Uint8Array when required

The tests have also been updated to ensure this check is done.

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

Bug fix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)