### PR TITLE
build(deps): bump bbs crate to released version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = []
 
 [dependencies]
 arrayref = "0.3"
-bbs = { version = "0.4.1", default-features = false, features = ["wasm"], git = "https://github.com/mikelodder7/ursa", branch = "wasm" }
+bbs = { version = "0.4.1", default-features = false, features = ["wasm"] }
 console_error_panic_hook = { version = "0.1.1", optional = true }
 js-sys = "0.3"
 rand = { version = "0.7", features = ["wasm-bindgen"] }


### PR DESCRIPTION
## Description

Bumps the dependency on [bbs](https://crates.io/crates/bbs) to the 0.4.1 release.

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

Using a stable release of the primary package dependency

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)