### PR TITLE
fix: set private key as defined on generate returntype

### DIFF
--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -34,9 +34,13 @@ export const DEFAULT_BLS12381_G1_PUBLIC_KEY_LENGTH = 48;
 
 export const DEFAULT_BLS12381_G2_PUBLIC_KEY_LENGTH = 96;
 
-export function generateBls12381G1KeyPair(seed?: Uint8Array): BlsKeyPair;
+export function generateBls12381G1KeyPair(
+  seed?: Uint8Array
+): Required<BlsKeyPair>;
 
-export function generateBls12381G2KeyPair(seed?: Uint8Array): BlsKeyPair;
+export function generateBls12381G2KeyPair(
+  seed?: Uint8Array
+): Required<BlsKeyPair>;
 
 export function bls12381toBbs(request: Bls12381ToBbsRequest): BbsKeyPair;
 


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
-->

## Description

return types of generate functions are incorrectly typed as possibly not
returning the private key.
<!--- Describe your changes in detail -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

having private key set to possibly be null or undefined meant that these cases
that were not possible to happen needed to be handled in downstream code

<!--- Why is this change required? What problem does it solve? -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [ ] Squash
- [x] Rebase (REVIEW COMMITS)
