### PR TITLE
fix: modifies the error variable to not produce a rust compiler warning

### DIFF
--- a/src/bbs_plus.rs
+++ b/src/bbs_plus.rs
@@ -101,7 +101,7 @@ pub fn bbs_sign(request: JsValue) -> Result<JsValue, JsValue> {
         .collect();
     match Signature::new(messages.as_slice(), &sk, &request.keyPair.publicKey) {
         Ok(sig) => Ok(serde_wasm_bindgen::to_value(&sig).unwrap()),
-        Err(e) => Err(JsValue::from("Failed to sign")),
+        Err(_e) => Err(JsValue::from("Failed to sign")),
     }
 }
 


### PR DESCRIPTION
This was producing a compiler warning when running yarn build. the suggested improvement from the
compiler was to add an underscore prefix because the variable was never used.

<!---
Provide a general summary of your changes in the Title above
-->

## Description

<!--- Describe your changes in detail -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [X] Squash
- [ ] Rebase (REVIEW COMMITS)