### PR TITLE
feat: migrate to async based api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.1.3"
 sha2 = "0.8"
 wasm-bindgen = "0.2.62"
+wasm-bindgen-futures = "0.4.18"
 web-sys = { version = "0.3.39", features = ['console'] }
 wee_alloc = { version = "0.4.2", optional = true }
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,6 @@
     }
   },
   "optionalDependencies": {
-    "@mattrglobal/node-bbs-signatures": "0.10.0"
+    "@mattrglobal/node-bbs-signatures": "0.11.0"
   }
 }

--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -30,12 +30,12 @@ echo "Building asm.js version"
 $WASM_2_JS $OPT --output $ASM 
 
 # WASM2JS only supports generation of es6
-# Whereas node environments require es5
+# Whereas node environments require es5 or cjs
 # Hence the folloing converts the import and export syntax
-sed -i -e 's/import {/\/\/ import {/g' $ASM
-sed -i -e 's/function asmFunc/var bbs = require('\''\.\/wasm'\''); function asmFunc/g' $ASM
-sed -i -e 's/{abort.*},memasmFunc/bbs, memasmFunc/g' $ASM
-sed -i -e 's/export var /module\.exports\./g' $ASM
+sed -i -e '/import {/d' $ASM
+sed -i -e '/export var /d' $ASM
+sed -i -e 's/{abort.*},memasmFunc/wbg, memasmFunc/g' $ASM
+sed -i -e 's/var retasmFunc = /module.exports = (wbg) => /' $ASM
 
 # Copy over package sources
 cp -r src/js/* lib/

--- a/src/bbs_plus.rs
+++ b/src/bbs_plus.rs
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 use crate::{bls12381::BbsKeyPair, BbsVerifyResponse, PoKOfSignatureProofWrapper};
 use bbs::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -88,7 +89,7 @@ wasm_impl!(
 );
 
 #[wasm_bindgen(js_name = sign)]
-pub fn bbs_sign(request: JsValue) -> Result<JsValue, JsValue> {
+pub async fn bbs_sign(request: JsValue) -> Result<JsValue, JsValue> {
     let request: BbsSignRequest = request.try_into()?;
     let sk = request
         .keyPair
@@ -106,7 +107,7 @@ pub fn bbs_sign(request: JsValue) -> Result<JsValue, JsValue> {
 }
 
 #[wasm_bindgen(js_name = verify)]
-pub fn bbs_verify(request: JsValue) -> Result<JsValue, JsValue> {
+pub async fn bbs_verify(request: JsValue) -> Result<JsValue, JsValue> {
     let res = request.try_into();
 
     let request: BbsVerifyRequest;
@@ -144,7 +145,7 @@ pub fn bbs_verify(request: JsValue) -> Result<JsValue, JsValue> {
 }
 
 #[wasm_bindgen(js_name = blindSignCommitment)]
-pub fn bbs_blind_signature_commitment(request: JsValue) -> Result<JsValue, JsValue> {
+pub async fn bbs_blind_signature_commitment(request: JsValue) -> Result<JsValue, JsValue> {
     let request: BlindSignatureContextRequest = serde_wasm_bindgen::from_value(request)?;
     if request.messages.len() != request.blinded.len() {
         return Err(JsValue::from("messages.len() != blinded.len()"));
@@ -179,7 +180,7 @@ pub fn bbs_blind_signature_commitment(request: JsValue) -> Result<JsValue, JsVal
 }
 
 #[wasm_bindgen(js_name = verifyBlind)]
-pub fn bbs_verify_blind_signature_proof(request: JsValue) -> Result<JsValue, JsValue> {
+pub async fn bbs_verify_blind_signature_proof(request: JsValue) -> Result<JsValue, JsValue> {
     let request: BlindSignatureVerifyContextRequest = request.try_into()?;
     let total = request.publicKey.message_count();
     if request.blinded.iter().any(|b| *b > total) {
@@ -201,7 +202,7 @@ pub fn bbs_verify_blind_signature_proof(request: JsValue) -> Result<JsValue, JsV
 }
 
 #[wasm_bindgen(js_name = blindSign)]
-pub fn bbs_blind_sign(request: JsValue) -> Result<JsValue, JsValue> {
+pub async fn bbs_blind_sign(request: JsValue) -> Result<JsValue, JsValue> {
     let request: BlindSignContextRequest = request.try_into()?;
     if request.messages.len() != request.known.len() {
         return Err(JsValue::from("messages.len() != known.len()"));
@@ -231,7 +232,7 @@ pub fn bbs_blind_sign(request: JsValue) -> Result<JsValue, JsValue> {
 }
 
 #[wasm_bindgen(js_name = unBlind)]
-pub fn bbs_get_unblinded_signature(request: JsValue) -> Result<JsValue, JsValue> {
+pub async fn bbs_get_unblinded_signature(request: JsValue) -> Result<JsValue, JsValue> {
     let request: UnblindSignatureRequest = request.try_into()?;
     Ok(
         serde_wasm_bindgen::to_value(&request.signature.to_unblinded(&request.blindingFactor))
@@ -240,7 +241,7 @@ pub fn bbs_get_unblinded_signature(request: JsValue) -> Result<JsValue, JsValue>
 }
 
 #[wasm_bindgen(js_name = createProof)]
-pub fn bbs_create_proof(request: JsValue) -> Result<JsValue, JsValue> {
+pub async fn bbs_create_proof(request: JsValue) -> Result<JsValue, JsValue> {
     let request: CreateProofRequest = request.try_into()?;
     if request
         .revealed
@@ -289,7 +290,7 @@ pub fn bbs_create_proof(request: JsValue) -> Result<JsValue, JsValue> {
 }
 
 #[wasm_bindgen(js_name = verifyProof)]
-pub fn bbs_verify_proof(request: JsValue) -> Result<JsValue, JsValue> {
+pub async fn bbs_verify_proof(request: JsValue) -> Result<JsValue, JsValue> {
     let res = serde_wasm_bindgen::from_value::<VerifyProofContext>(request);
     let request: VerifyProofContext;
     match res {

--- a/src/bls12381.rs
+++ b/src/bls12381.rs
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 use crate::{BbsVerifyResponse, PoKOfSignatureProofWrapper};
 use bbs::prelude::*;
 use pairing_plus::{
@@ -88,8 +89,8 @@ wasm_impl!(
 /// returned vector is the concatenation of first the private key (32 bytes)
 /// followed by the public key (96) bytes.
 #[wasm_bindgen(js_name = generateBls12381G2KeyPair)]
-pub fn bls_generate_g2_key(seed: Option<Vec<u8>>) -> JsValue {
-    bls_generate_keypair::<G2>(seed)
+pub async fn bls_generate_g2_key(seed: Option<Vec<u8>>) -> Result<JsValue, JsValue> {
+    Ok(bls_generate_keypair::<G2>(seed))
 }
 
 /// Generate a BLS 12-381 key pair.
@@ -99,13 +100,13 @@ pub fn bls_generate_g2_key(seed: Option<Vec<u8>>) -> JsValue {
 /// returned vector is the concatenation of first the private key (32 bytes)
 /// followed by the public key (48) bytes.
 #[wasm_bindgen(js_name = generateBls12381G1KeyPair)]
-pub fn bls_generate_g1_key(seed: Option<Vec<u8>>) -> JsValue {
-    bls_generate_keypair::<G1>(seed)
+pub async fn bls_generate_g1_key(seed: Option<Vec<u8>>) -> Result<JsValue, JsValue> {
+    Ok(bls_generate_keypair::<G1>(seed))
 }
 
 /// Get the BBS public key associated with the private key
 #[wasm_bindgen(js_name = bls12381toBbs)]
-pub fn bls_to_bbs_key(request: JsValue) -> Result<JsValue, JsValue> {
+pub async fn bls_to_bbs_key(request: JsValue) -> Result<JsValue, JsValue> {
     let request: Bls12381ToBbsRequest = request.try_into()?;
     if request.messageCount == 0 {
         return Err(JsValue::from_str("Failed to convert key"));
@@ -135,7 +136,7 @@ pub fn bls_to_bbs_key(request: JsValue) -> Result<JsValue, JsValue> {
 
 /// Signs a set of messages with a BLS 12-381 key pair and produces a BBS signature
 #[wasm_bindgen(js_name = blsSign)]
-pub fn bls_sign(request: JsValue) -> Result<JsValue, JsValue> {
+pub async fn bls_sign(request: JsValue) -> Result<JsValue, JsValue> {
     let request: BlsBbsSignRequest = request.try_into()?;
     let dpk_bytes = request.keyPair.publicKey.unwrap();
     let dpk = DeterministicPublicKey::from(array_ref![dpk_bytes, 0, G2_COMPRESSED_SIZE]);
@@ -165,7 +166,7 @@ pub fn bls_sign(request: JsValue) -> Result<JsValue, JsValue> {
 
 /// Verifies a BBS+ signature for a set of messages with a with a BLS 12-381 public key
 #[wasm_bindgen(js_name = blsVerify)]
-pub fn bls_verify(request: JsValue) -> Result<JsValue, JsValue> {
+pub async fn bls_verify(request: JsValue) -> Result<JsValue, JsValue> {
     let res = request.try_into();
     let result: BlsBbsVerifyRequest;
     match res {
@@ -207,7 +208,7 @@ pub fn bls_verify(request: JsValue) -> Result<JsValue, JsValue> {
 
 /// Creates a BBS+ PoK
 #[wasm_bindgen(js_name = blsCreateProof)]
-pub fn bls_create_proof(request: JsValue) -> Result<JsValue, JsValue> {
+pub async fn bls_create_proof(request: JsValue) -> Result<JsValue, JsValue> {
     let request: BlsCreateProofRequest = request.try_into()?;
     if request.revealed.iter().any(|r| *r > request.messages.len()) {
         return Err(JsValue::from("revealed value is out of bounds"));
@@ -251,7 +252,7 @@ pub fn bls_create_proof(request: JsValue) -> Result<JsValue, JsValue> {
 
 /// Verify a BBS+ PoK
 #[wasm_bindgen(js_name = blsVerifyProof)]
-pub fn bls_verify_proof(request: JsValue) -> Result<JsValue, JsValue> {
+pub async fn bls_verify_proof(request: JsValue) -> Result<JsValue, JsValue> {
     let res = serde_wasm_bindgen::from_value::<BlsVerifyProofContext>(request);
     let request: BlsVerifyProofContext;
     match res {

--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -36,26 +36,38 @@ export const DEFAULT_BLS12381_G2_PUBLIC_KEY_LENGTH = 96;
 
 export function generateBls12381G1KeyPair(
   seed?: Uint8Array
-): Required<BlsKeyPair>;
+): Promise<Required<BlsKeyPair>>;
 
 export function generateBls12381G2KeyPair(
   seed?: Uint8Array
-): Required<BlsKeyPair>;
+): Promise<Required<BlsKeyPair>>;
 
-export function bls12381toBbs(request: Bls12381ToBbsRequest): BbsKeyPair;
+export function bls12381toBbs(
+  request: Bls12381ToBbsRequest
+): Promise<BbsKeyPair>;
 
-export function sign(request: BbsSignRequest): Uint8Array;
+export function sign(request: BbsSignRequest): Promise<Uint8Array>;
 
-export function blsSign(request: BlsBbsSignRequest): Uint8Array;
+export function blsSign(request: BlsBbsSignRequest): Promise<Uint8Array>;
 
-export function verify(request: BbsVerifyRequest): BbsVerifyResult;
+export function verify(request: BbsVerifyRequest): Promise<BbsVerifyResult>;
 
-export function blsVerify(request: BlsBbsVerifyRequest): BbsVerifyResult;
+export function blsVerify(
+  request: BlsBbsVerifyRequest
+): Promise<BbsVerifyResult>;
 
-export function createProof(request: BbsCreateProofRequest): Uint8Array;
+export function createProof(
+  request: BbsCreateProofRequest
+): Promise<Uint8Array>;
 
-export function verifyProof(request: BbsVerifyProofRequest): BbsVerifyResult;
+export function verifyProof(
+  request: BbsVerifyProofRequest
+): Promise<BbsVerifyResult>;
 
-export function blsCreateProof(request: BbsCreateProofRequest): Uint8Array;
+export function blsCreateProof(
+  request: BbsCreateProofRequest
+): Promise<Uint8Array>;
 
-export function blsVerifyProof(request: BbsVerifyProofRequest): BbsVerifyResult;
+export function blsVerifyProof(
+  request: BbsVerifyProofRequest
+): Promise<BbsVerifyResult>;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -35,6 +35,16 @@ try {
 if (useWasm) {
   const wasm = require("./wasm");
 
+  // Casts a rejected promise to an error rather than a
+  // simple string result
+  const throwErrorOnRejectedPromise = async (promise) => {
+    try {
+      return await promise;
+    } catch (ex) {
+      throw new Error(ex);
+    }
+  };
+
   module.exports.DEFAULT_BLS12381_PRIVATE_KEY_LENGTH = 32;
 
   module.exports.DEFAULT_BLS12381_G1_PUBLIC_KEY_LENGTH = 48;
@@ -43,24 +53,28 @@ if (useWasm) {
 
   module.exports.BBS_SIGNATURE_LENGTH = 112;
 
-  module.exports.generateBls12381G1KeyPair = (seed) => {
-    var result = wasm.generateBls12381G1KeyPair(seed ? seed : null);
+  module.exports.generateBls12381G1KeyPair = async (seed) => {
+    var result = await throwErrorOnRejectedPromise(
+      wasm.generateBls12381G1KeyPair(seed ? seed : null)
+    );
     return {
       secretKey: new Uint8Array(result.secretKey),
       publicKey: new Uint8Array(result.publicKey),
     };
   };
 
-  module.exports.generateBls12381G2KeyPair = (seed) => {
-    var result = wasm.generateBls12381G2KeyPair(seed ? seed : null);
+  module.exports.generateBls12381G2KeyPair = async (seed) => {
+    var result = await throwErrorOnRejectedPromise(
+      wasm.generateBls12381G2KeyPair(seed ? seed : null)
+    );
     return {
       secretKey: new Uint8Array(result.secretKey),
       publicKey: new Uint8Array(result.publicKey),
     };
   };
 
-  module.exports.bls12381toBbs = (request) => {
-    var result = wasm.bls12381toBbs(request);
+  module.exports.bls12381toBbs = async (request) => {
+    var result = await throwErrorOnRejectedPromise(wasm.bls12381toBbs(request));
     return {
       publicKey: new Uint8Array(result.publicKey),
       secretKey: result.secretKey
@@ -70,21 +84,27 @@ if (useWasm) {
     };
   };
 
-  module.exports.Bls12381ToBbsRequest = wasm.Bls12381ToBbsRequest;
+  module.exports.sign = (request) =>
+    throwErrorOnRejectedPromise(wasm.sign(request));
 
-  module.exports.sign = wasm.sign;
+  module.exports.blsSign = (request) =>
+    throwErrorOnRejectedPromise(wasm.blsSign(request));
 
-  module.exports.blsSign = wasm.blsSign;
+  module.exports.verify = (request) =>
+    throwErrorOnRejectedPromise(wasm.verify(request));
 
-  module.exports.verify = wasm.verify;
+  module.exports.blsVerify = (request) =>
+    throwErrorOnRejectedPromise(wasm.blsVerify(request));
 
-  module.exports.blsVerify = wasm.blsVerify;
+  module.exports.createProof = (request) =>
+    throwErrorOnRejectedPromise(wasm.createProof(request));
 
-  module.exports.createProof = wasm.createProof;
+  module.exports.blsCreateProof = (request) =>
+    throwErrorOnRejectedPromise(wasm.blsCreateProof(request));
 
-  module.exports.blsCreateProof = wasm.blsCreateProof;
+  module.exports.verifyProof = (request) =>
+    throwErrorOnRejectedPromise(wasm.verifyProof(request));
 
-  module.exports.verifyProof = wasm.verifyProof;
-
-  module.exports.blsVerifyProof = wasm.blsVerifyProof;
+  module.exports.blsVerifyProof = (request) =>
+    throwErrorOnRejectedPromise(wasm.blsVerifyProof(request));
 }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -54,6 +54,7 @@ if (useWasm) {
   module.exports.BBS_SIGNATURE_LENGTH = 112;
 
   module.exports.generateBls12381G1KeyPair = async (seed) => {
+    await wasm.waitReady();
     var result = await throwErrorOnRejectedPromise(
       wasm.generateBls12381G1KeyPair(seed ? seed : null)
     );
@@ -64,6 +65,7 @@ if (useWasm) {
   };
 
   module.exports.generateBls12381G2KeyPair = async (seed) => {
+    await wasm.waitReady();
     var result = await throwErrorOnRejectedPromise(
       wasm.generateBls12381G2KeyPair(seed ? seed : null)
     );
@@ -74,6 +76,7 @@ if (useWasm) {
   };
 
   module.exports.bls12381toBbs = async (request) => {
+    await wasm.waitReady();
     var result = await throwErrorOnRejectedPromise(wasm.bls12381toBbs(request));
     return {
       publicKey: new Uint8Array(result.publicKey),
@@ -84,27 +87,43 @@ if (useWasm) {
     };
   };
 
-  module.exports.sign = (request) =>
-    throwErrorOnRejectedPromise(wasm.sign(request));
+  module.exports.sign = async (request) => {
+    await wasm.waitReady();
+    return await throwErrorOnRejectedPromise(wasm.sign(request));
+  };
 
-  module.exports.blsSign = (request) =>
-    throwErrorOnRejectedPromise(wasm.blsSign(request));
+  module.exports.blsSign = async (request) => {
+    await wasm.waitReady();
+    return await throwErrorOnRejectedPromise(wasm.blsSign(request));
+  };
 
-  module.exports.verify = (request) =>
-    throwErrorOnRejectedPromise(wasm.verify(request));
+  module.exports.verify = async (request) => {
+    await wasm.waitReady();
+    return await throwErrorOnRejectedPromise(wasm.verify(request));
+  };
 
-  module.exports.blsVerify = (request) =>
-    throwErrorOnRejectedPromise(wasm.blsVerify(request));
+  module.exports.blsVerify = async (request) => {
+    await wasm.waitReady();
+    return await throwErrorOnRejectedPromise(wasm.blsVerify(request));
+  };
 
-  module.exports.createProof = (request) =>
-    throwErrorOnRejectedPromise(wasm.createProof(request));
+  module.exports.createProof = async (request) => {
+    await wasm.waitReady();
+    return await throwErrorOnRejectedPromise(wasm.createProof(request));
+  };
 
-  module.exports.blsCreateProof = (request) =>
-    throwErrorOnRejectedPromise(wasm.blsCreateProof(request));
+  module.exports.blsCreateProof = async (request) => {
+    await wasm.waitReady();
+    return await throwErrorOnRejectedPromise(wasm.blsCreateProof(request));
+  };
 
-  module.exports.verifyProof = (request) =>
-    throwErrorOnRejectedPromise(wasm.verifyProof(request));
+  module.exports.verifyProof = async (request) => {
+    await wasm.waitReady();
+    return await throwErrorOnRejectedPromise(wasm.verifyProof(request));
+  };
 
-  module.exports.blsVerifyProof = (request) =>
-    throwErrorOnRejectedPromise(wasm.blsVerifyProof(request));
+  module.exports.blsVerifyProof = async (request) => {
+    await wasm.waitReady();
+    return await throwErrorOnRejectedPromise(wasm.blsVerifyProof(request));
+  };
 }

--- a/src/js/wasm_helper.js
+++ b/src/js/wasm_helper.js
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 - MATTR Limited
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const asm = require("./wasm_asm");
 const bytes = require("./wasm_wasm");
 const imports = require("./wasm");
@@ -30,8 +43,8 @@ module.exports = function getWasmInstance() {
   }
 
   // if we have a valid supplied asm.js, return that
-  if (asm) {
-    return asm;
+  if (asm()) {
+    return asm();
   }
 
   console.error(FAILED_INITIALIZE_ERROR);

--- a/src/js/wasm_helper.js
+++ b/src/js/wasm_helper.js
@@ -21,7 +21,7 @@ const {
   BBS_SIGNATURES_MODES,
 } = require("./util");
 
-module.exports = function getWasmInstance() {
+module.exports = async function () {
   if (
     !process.env.BBS_SIGNATURES_MODE ||
     process.env.BBS_SIGNATURES_MODE !== BBS_SIGNATURES_MODES.asmjs
@@ -30,10 +30,11 @@ module.exports = function getWasmInstance() {
       if (!WebAssembly) {
         throw new Error(WEB_ASSEMBLY_NOT_FOUND_ERROR);
       }
-      const wasmModule = new WebAssembly.Module(bytes);
-      return new WebAssembly.Instance(wasmModule, {
-        __wbindgen_placeholder__: imports,
-      }).exports;
+      return (
+        await WebAssembly.instantiate(bytes, {
+          __wbindgen_placeholder__: imports,
+        })
+      ).instance.exports;
     } catch (error) {
       console.log(
         "The following error occurred in attempting to load the WASM. Attempting to use ASM fallback."
@@ -43,10 +44,9 @@ module.exports = function getWasmInstance() {
   }
 
   // if we have a valid supplied asm.js, return that
-  if (asm()) {
-    return asm();
+  if (asm) {
+    return asm;
   }
-
   console.error(FAILED_INITIALIZE_ERROR);
   console.error(error);
 

--- a/tests/bbsSignature/createProof.bbsSignature.spec.ts
+++ b/tests/bbsSignature/createProof.bbsSignature.spec.ts
@@ -17,7 +17,7 @@ import { base64Decode, stringToBytes } from "../utilities";
 
 describe("bbsSignature", () => {
   describe("createProof", () => {
-    it("should create proof revealing single message from single message signature", () => {
+    it("should create proof revealing single message from single message signature", async () => {
       const messages = [stringToBytes("RmtnDBJHso5iSg==")];
       const bbsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pboZyjM38YgjaUBcjftZi5gb58Qz13XeRJpiuUHH06I7/1Eb8oVtIW5SGMNfKaqKhBAAAAAYPPztgxfWWw01/0SSug1oLfVuI4XUqhgyZ3rS6eTkOLjnyR3ObXb0XCD2Mfcxiv6w=="
@@ -34,12 +34,12 @@ describe("bbsSignature", () => {
         revealed: [0],
       };
 
-      const proof = createProof(request);
+      const proof = await createProof(request);
       expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(383);
     });
 
-    it("should create proof revealing all messages from multi-message signature", () => {
+    it("should create proof revealing all messages from multi-message signature", async () => {
       const messages = [
         stringToBytes("J42AxhciOVkE9w=="),
         stringToBytes("PNMnARWIHP+s2g=="),
@@ -61,12 +61,12 @@ describe("bbsSignature", () => {
         revealed: [0, 1, 2],
       };
 
-      const proof = createProof(request);
+      const proof = await createProof(request);
       expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(383); //TODO add a reason for this and some constants?
     });
 
-    it("should create proof revealing single message from multi-message signature", () => {
+    it("should create proof revealing single message from multi-message signature", async () => {
       const messages = [
         stringToBytes("J42AxhciOVkE9w=="),
         stringToBytes("PNMnARWIHP+s2g=="),
@@ -88,12 +88,12 @@ describe("bbsSignature", () => {
         revealed: [0],
       };
 
-      const proof = createProof(request);
+      const proof = await createProof(request);
       expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(447); //TODO add a reason for this and some constants?
     });
 
-    it("should create proof revealing multiple messages from multi-message signature", () => {
+    it("should create proof revealing multiple messages from multi-message signature", async () => {
       const messages = [
         stringToBytes("J42AxhciOVkE9w=="),
         stringToBytes("PNMnARWIHP+s2g=="),
@@ -115,14 +115,14 @@ describe("bbsSignature", () => {
         revealed: [0, 2],
       };
 
-      const proof = createProof(request);
+      const proof = await createProof(request);
       expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(415); //TODO evaluate this length properly add a reason for this and some constants?
     });
   });
 
   describe("blsCreateProof", () => {
-    it("should create proof revealing single message from single message signature", () => {
+    it("should create proof revealing single message from single message signature", async () => {
       const messages = [stringToBytes("uzAoQFqLgReidw==")];
       const blsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb"
@@ -139,12 +139,12 @@ describe("bbsSignature", () => {
         revealed: [0],
       };
 
-      const proof = blsCreateProof(request);
+      const proof = await blsCreateProof(request);
       expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(383);
     });
 
-    it("should create proof revealing all messages from multi-message signature", () => {
+    it("should create proof revealing all messages from multi-message signature", async () => {
       const messages = [
         stringToBytes("C+n1rPz1/tVzPg=="),
         stringToBytes("h3x8cbySqC4rLA=="),
@@ -166,12 +166,12 @@ describe("bbsSignature", () => {
         revealed: [0, 1, 2],
       };
 
-      const proof = blsCreateProof(request);
+      const proof = await blsCreateProof(request);
       expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(383); //TODO add a reason for this and some constants?
     });
 
-    it("should create proof revealing single message from multi-message signature", () => {
+    it("should create proof revealing single message from multi-message signature", async () => {
       const messages = [
         stringToBytes("uiSKIfNoO2rMrA=="),
         stringToBytes("lMoHHrFx0LxwAw=="),
@@ -193,12 +193,12 @@ describe("bbsSignature", () => {
         revealed: [0],
       };
 
-      const proof = blsCreateProof(request);
+      const proof = await blsCreateProof(request);
       expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(447); //TODO add a reason for this and some constants?
     });
 
-    it("should create proof revealing multiple messages from multi-message signature", () => {
+    it("should create proof revealing multiple messages from multi-message signature", async () => {
       const messages = [
         stringToBytes("uiSKIfNoO2rMrA=="),
         stringToBytes("lMoHHrFx0LxwAw=="),
@@ -220,7 +220,7 @@ describe("bbsSignature", () => {
         revealed: [0, 2],
       };
 
-      const proof = blsCreateProof(request);
+      const proof = await blsCreateProof(request);
       expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(415); //TODO evaluate this length properly add a reason for this and some constants?
     });

--- a/tests/bbsSignature/sign.bbsSignature.spec.ts
+++ b/tests/bbsSignature/sign.bbsSignature.spec.ts
@@ -25,12 +25,24 @@ import {
 import { stringToBytes } from "../utilities";
 
 describe("bbsSignature", () => {
-  const blsKeyPair = generateBls12381G2KeyPair();
-  describe("sign", () => {
-    const bbsKeyPair = bls12381toBbs({ keyPair: blsKeyPair, messageCount: 3 });
+  let blsKeyPair: BlsKeyPair;
 
-    it("should sign a single message", () => {
-      const bbsKeyPair = bls12381toBbs({
+  beforeAll(async () => {
+    blsKeyPair = await generateBls12381G2KeyPair();
+  });
+
+  describe("sign", () => {
+    let bbsKeyPair: BbsKeyPair;
+
+    beforeAll(async () => {
+      bbsKeyPair = await bls12381toBbs({
+        keyPair: blsKeyPair,
+        messageCount: 3,
+      });
+    });
+
+    it("should sign a single message", async () => {
+      const bbsKeyPair = await bls12381toBbs({
         keyPair: blsKeyPair,
         messageCount: 1,
       });
@@ -38,12 +50,12 @@ describe("bbsSignature", () => {
         keyPair: bbsKeyPair,
         messages: [stringToBytes("ExampleMessage")],
       };
-      const signature = sign(request);
+      const signature = await sign(request);
       expect(signature).toBeInstanceOf(Uint8Array);
       expect(signature.length).toEqual(BBS_SIGNATURE_LENGTH);
     });
 
-    it("should sign multiple messages", () => {
+    it("should sign multiple messages", async () => {
       const request: BbsSignRequest = {
         keyPair: bbsKeyPair,
         messages: [
@@ -52,12 +64,12 @@ describe("bbsSignature", () => {
           stringToBytes("ExampleMessage3"),
         ],
       };
-      const signature = sign(request);
+      const signature = await sign(request);
       expect(signature).toBeInstanceOf(Uint8Array);
       expect(signature.length).toEqual(BBS_SIGNATURE_LENGTH);
     });
 
-    it("should sign multiple messages when public key supports more", () => {
+    it("should sign multiple messages when public key supports more", async () => {
       const request: BbsSignRequest = {
         keyPair: bbsKeyPair,
         messages: [
@@ -65,12 +77,12 @@ describe("bbsSignature", () => {
           stringToBytes("ExampleMessage"),
         ],
       };
-      const signature = sign(request);
+      const signature = await sign(request);
       expect(signature).toBeInstanceOf(Uint8Array);
       expect(signature.length).toEqual(BBS_SIGNATURE_LENGTH);
     });
 
-    it("should throw error if secret key not present", () => {
+    it("should throw error if secret key not present", async () => {
       const bbsKey: BbsKeyPair = {
         publicKey: bbsKeyPair.publicKey,
         messageCount: bbsKeyPair.messageCount,
@@ -79,11 +91,11 @@ describe("bbsSignature", () => {
         keyPair: bbsKey,
         messages: [stringToBytes("ExampleMessage")],
       };
-      expect(() => sign(request)).toThrowError("Failed to sign");
+      await expect(sign(request)).rejects.toThrowError("Failed to sign");
     });
 
-    it("should throw error if public key does not support message number", () => {
-      const bbsKeyPair = bls12381toBbs({
+    it("should throw error if public key does not support message number", async () => {
+      const bbsKeyPair = await bls12381toBbs({
         keyPair: blsKeyPair,
         messageCount: 1,
       });
@@ -95,22 +107,22 @@ describe("bbsSignature", () => {
           stringToBytes("ExampleMessage"),
         ],
       };
-      expect(() => sign(request)).toThrowError("Failed to sign");
+      await expect(sign(request)).rejects.toThrowError("Failed to sign");
     });
   });
 
   describe("blsSign", () => {
-    it("should sign a single message", () => {
+    it("should sign a single message", async () => {
       const request: BlsBbsSignRequest = {
         keyPair: blsKeyPair,
         messages: [stringToBytes("ExampleMessage")],
       };
-      const signature = blsSign(request);
+      const signature = await blsSign(request);
       expect(signature).toBeInstanceOf(Uint8Array);
       expect(signature.length).toEqual(BBS_SIGNATURE_LENGTH);
     });
 
-    it("should sign multiple messages", () => {
+    it("should sign multiple messages", async () => {
       const request: BlsBbsSignRequest = {
         keyPair: blsKeyPair,
         messages: [
@@ -119,12 +131,12 @@ describe("bbsSignature", () => {
           stringToBytes("ExampleMessage3"),
         ],
       };
-      const signature = blsSign(request);
+      const signature = await blsSign(request);
       expect(signature).toBeInstanceOf(Uint8Array);
       expect(signature.length).toEqual(BBS_SIGNATURE_LENGTH);
     });
 
-    it("should throw error if secret key not present", () => {
+    it("should throw error if secret key not present", async () => {
       const blsKey: BlsKeyPair = {
         publicKey: blsKeyPair.publicKey,
       };
@@ -136,15 +148,17 @@ describe("bbsSignature", () => {
           stringToBytes("ExampleMessage3"),
         ],
       };
-      expect(() => blsSign(request)).toThrowError("Failed to sign");
+      await expect(blsSign(request)).rejects.toThrowError("Failed to sign");
     });
 
-    it("should throw error when messages empty", () => {
+    it("should throw error when messages empty", async () => {
       const request: BlsBbsSignRequest = {
         keyPair: blsKeyPair,
         messages: [],
       };
-      expect(() => blsSign(request)).toThrowError("Failed to convert key");
+      await expect(blsSign(request)).rejects.toThrowError(
+        "Failed to convert key"
+      );
     });
   });
 });

--- a/tests/bbsSignature/verify.bbsSignature.spec.ts
+++ b/tests/bbsSignature/verify.bbsSignature.spec.ts
@@ -22,14 +22,20 @@ import {
   BlsBbsSignRequest,
   blsSign,
   BlsBbsVerifyRequest,
+  BlsKeyPair,
 } from "../../lib";
 import { base64Decode, stringToBytes } from "../utilities";
 
 describe("bbsSignature", () => {
   describe("verify", () => {
-    const blsKeyPair = generateBls12381G2KeyPair();
-    it("should verify valid signature with a single message", () => {
-      const BbsPublicKey = bls12381toBbs({
+    let blsKeyPair: BlsKeyPair;
+
+    beforeAll(async () => {
+      blsKeyPair = await generateBls12381G2KeyPair();
+    });
+
+    it("should verify valid signature with a single message", async () => {
+      const BbsPublicKey = await bls12381toBbs({
         keyPair: blsKeyPair,
         messageCount: 1,
       });
@@ -37,18 +43,18 @@ describe("bbsSignature", () => {
         keyPair: BbsPublicKey,
         messages: [stringToBytes("ExampleMessage")],
       };
-      const signature = sign(request);
+      const signature = await sign(request);
       const verifyRequest: BbsVerifyRequest = {
         publicKey: BbsPublicKey.publicKey,
         messages: [stringToBytes("ExampleMessage")],
         signature,
       };
-      const result = verify(verifyRequest);
+      const result = await verify(verifyRequest);
       expect(result.verified).toBeTruthy();
     });
 
-    it("should verify valid signature with multiple messages", () => {
-      const BbsPublicKey = bls12381toBbs({
+    it("should verify valid signature with multiple messages", async () => {
+      const BbsPublicKey = await bls12381toBbs({
         keyPair: blsKeyPair,
         messageCount: 3,
       });
@@ -60,7 +66,7 @@ describe("bbsSignature", () => {
           stringToBytes("ExampleMessage3"),
         ],
       };
-      const signature = sign(request);
+      const signature = await sign(request);
       const verifyRequest: BbsVerifyRequest = {
         publicKey: BbsPublicKey.publicKey,
         messages: [
@@ -70,12 +76,12 @@ describe("bbsSignature", () => {
         ],
         signature: signature,
       };
-      expect(verify(verifyRequest).verified).toBeTruthy();
+      expect((await verify(verifyRequest)).verified).toBeTruthy();
     });
 
-    it("should not verify valid signature with wrong single message", () => {
+    it("should not verify valid signature with wrong single message", async () => {
       const messages = [stringToBytes("BadMessage")];
-      const BbsPublicKey = bls12381toBbs({
+      const BbsPublicKey = await bls12381toBbs({
         keyPair: blsKeyPair,
         messageCount: 1,
       });
@@ -86,16 +92,16 @@ describe("bbsSignature", () => {
           "kTV8dar9xLWQZ5EzaWYqTRmgA6dw6wcrUw5c///crRD2QQPXX9Di+lgCPCXAA5D8Pytuh6bNSx6k4NZTR9KfSNdaejKl2zTU9poRfzZ2SIskdgSHTZ2y7jLm/UEGKsAs3tticBVj1Pm2GNhQI/OlXQ=="
         ),
       };
-      expect(verify(verifyRequest).verified).toBeFalsy();
+      expect((await verify(verifyRequest)).verified).toBeFalsy();
     });
 
-    it("should not verify valid signature with wrong messages", () => {
+    it("should not verify valid signature with wrong messages", async () => {
       const messages = [
         stringToBytes("BadMessage"),
         stringToBytes("BadMessage"),
         stringToBytes("BadMessage"),
       ];
-      const BbsPublicKey = bls12381toBbs({
+      const BbsPublicKey = await bls12381toBbs({
         keyPair: blsKeyPair,
         messageCount: 3,
       });
@@ -106,11 +112,11 @@ describe("bbsSignature", () => {
           "jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ=="
         ),
       };
-      expect(verify(verifyRequest).verified).toBeFalsy();
+      expect((await verify(verifyRequest)).verified).toBeFalsy();
     });
 
-    it("should throw error when messages empty", () => {
-      const BbsPublicKey = bls12381toBbs({
+    it("should throw error when messages empty", async () => {
+      const BbsPublicKey = await bls12381toBbs({
         keyPair: blsKeyPair,
         messageCount: 1,
       });
@@ -121,10 +127,10 @@ describe("bbsSignature", () => {
           "jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ=="
         ),
       };
-      expect(verify(request).verified).toBeFalsy();
+      expect((await verify(request)).verified).toBeFalsy();
     });
 
-    it("should throw error when public key invalid length", () => {
+    it("should throw error when public key invalid length", async () => {
       const request: BbsVerifyRequest = {
         publicKey: new Uint8Array(20),
         messages: [],
@@ -132,26 +138,31 @@ describe("bbsSignature", () => {
           "jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ=="
         ),
       };
-      expect(verify(request).verified).toBeFalsy();
+      expect((await verify(request)).verified).toBeFalsy();
     });
   });
   describe("blsVerify", () => {
-    const blsKeyPair = generateBls12381G2KeyPair();
-    it("should verify valid signature with a single message", () => {
+    let blsKeyPair: BlsKeyPair;
+
+    beforeAll(async () => {
+      blsKeyPair = await generateBls12381G2KeyPair();
+    });
+
+    it("should verify valid signature with a single message", async () => {
       const request: BlsBbsSignRequest = {
         keyPair: blsKeyPair,
         messages: [stringToBytes("ExampleMessage")],
       };
-      const signature = blsSign(request);
+      const signature = await blsSign(request);
       const verifyRequest: BlsBbsVerifyRequest = {
         publicKey: blsKeyPair.publicKey,
         messages: [stringToBytes("ExampleMessage")],
         signature,
       };
-      expect(blsVerify(verifyRequest).verified).toBeTruthy();
+      expect((await blsVerify(verifyRequest)).verified).toBeTruthy();
     });
 
-    it("should verify valid signature with multiple messages", () => {
+    it("should verify valid signature with multiple messages", async () => {
       const request: BlsBbsSignRequest = {
         keyPair: blsKeyPair,
         messages: [
@@ -160,7 +171,7 @@ describe("bbsSignature", () => {
           stringToBytes("ExampleMessage3"),
         ],
       };
-      const signature = blsSign(request);
+      const signature = await blsSign(request);
       const verifyRequest: BlsBbsVerifyRequest = {
         publicKey: blsKeyPair.publicKey,
         messages: [
@@ -170,10 +181,10 @@ describe("bbsSignature", () => {
         ],
         signature,
       };
-      expect(blsVerify(verifyRequest).verified).toBeTruthy();
+      expect((await blsVerify(verifyRequest)).verified).toBeTruthy();
     });
 
-    it("should not verify valid signature with wrong single message", () => {
+    it("should not verify valid signature with wrong single message", async () => {
       const messages = [stringToBytes("BadMessage")];
       const verifyRequest: BlsBbsVerifyRequest = {
         publicKey: blsKeyPair.publicKey,
@@ -182,10 +193,10 @@ describe("bbsSignature", () => {
           "kTV8dar9xLWQZ5EzaWYqTRmgA6dw6wcrUw5c///crRD2QQPXX9Di+lgCPCXAA5D8Pytuh6bNSx6k4NZTR9KfSNdaejKl2zTU9poRfzZ2SIskdgSHTZ2y7jLm/UEGKsAs3tticBVj1Pm2GNhQI/OlXQ=="
         ),
       };
-      expect(blsVerify(verifyRequest).verified).toBeFalsy();
+      expect((await blsVerify(verifyRequest)).verified).toBeFalsy();
     });
 
-    it("should not verify valid signature with wrong messages", () => {
+    it("should not verify valid signature with wrong messages", async () => {
       const messages = [
         stringToBytes("BadMessage"),
         stringToBytes("BadMessage"),
@@ -198,10 +209,10 @@ describe("bbsSignature", () => {
           "jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ=="
         ),
       };
-      expect(verify(verifyRequest).verified).toBeFalsy();
+      expect((await verify(verifyRequest)).verified).toBeFalsy();
     });
 
-    it("should not verify when messages empty", () => {
+    it("should not verify when messages empty", async () => {
       const request: BlsBbsVerifyRequest = {
         publicKey: blsKeyPair.publicKey,
         messages: [],
@@ -209,10 +220,10 @@ describe("bbsSignature", () => {
           "jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ=="
         ),
       };
-      expect(blsVerify(request).verified).toBeFalsy();
+      expect((await blsVerify(request)).verified).toBeFalsy();
     });
 
-    it("should not verify when public key invalid length", () => {
+    it("should not verify when public key invalid length", async () => {
       const request: BlsBbsVerifyRequest = {
         publicKey: new Uint8Array(20),
         messages: [],
@@ -220,7 +231,7 @@ describe("bbsSignature", () => {
           "jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ=="
         ),
       };
-      expect(blsVerify(request).verified).toBeFalsy();
+      expect((await blsVerify(request)).verified).toBeFalsy();
     });
   });
 });

--- a/tests/bbsSignature/verifyProof.bbsSignature.spec.ts
+++ b/tests/bbsSignature/verifyProof.bbsSignature.spec.ts
@@ -22,7 +22,7 @@ import { base64Decode, stringToBytes } from "../utilities";
 
 describe("bbsSignature", () => {
   describe("verifyProof", () => {
-    it("should verify proof with all messages revealed from single message signature", () => {
+    it("should verify proof with all messages revealed from single message signature", async () => {
       const messages = [stringToBytes("KNK0ITRAF+NrGg==")];
       const bbsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pboZyjM38YgjaUBcjftZi5gb58Qz13XeRJpiuUHH06I7/1Eb8oVtIW5SGMNfKaqKhBAAAAAYPPztgxfWWw01/0SSug1oLfVuI4XUqhgyZ3rS6eTkOLjnyR3ObXb0XCD2Mfcxiv6w=="
@@ -38,10 +38,10 @@ describe("bbsSignature", () => {
         nonce: stringToBytes("v3bb/Mz+JajUdiM2URfZYcPuqxw="),
       };
 
-      expect(verifyProof(request).verified).toBeTruthy();
+      expect((await verifyProof(request)).verified).toBeTruthy();
     });
 
-    it("should verify proof with all messages revealed from multi message signature", () => {
+    it("should verify proof with all messages revealed from multi message signature", async () => {
       const messages = [
         stringToBytes("BVB6lAn912sz9Q=="),
         stringToBytes("b45VqRkIo5R5Zw=="),
@@ -61,10 +61,10 @@ describe("bbsSignature", () => {
         nonce: stringToBytes("dVPpzuQtJVAZzAw73beWiXLtoT4="),
       };
 
-      expect(verifyProof(request).verified).toBeTruthy();
+      expect((await verifyProof(request)).verified).toBeTruthy();
     });
 
-    it("should verify proof with one message revealed from multi-message signature", () => {
+    it("should verify proof with one message revealed from multi-message signature", async () => {
       const messages = [
         stringToBytes("+FxEv3VLcNZ8sA=="),
         stringToBytes("eI2RcRExnbP8hw=="),
@@ -86,10 +86,10 @@ describe("bbsSignature", () => {
         nonce: stringToBytes("NoWZhtX+u1wWLtUfPMmku1FtU2I="),
       };
 
-      expect(verifyProof(request).verified).toBeTruthy();
+      expect((await verifyProof(request)).verified).toBeTruthy();
     });
 
-    it("should not verify with bad nonce", () => {
+    it("should not verify with bad nonce", async () => {
       const messages = [stringToBytes("KNK0ITRAF+NrGg==")];
       const bbsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pboZyjM38YgjaUBcjftZi5gb58Qz13XeRJpiuUHH06I7/1Eb8oVtIW5SGMNfKaqKhBAAAAAYPPztgxfWWw01/0SSug1oLfVuI4XUqhgyZ3rS6eTkOLjnyR3ObXb0XCD2Mfcxiv6w=="
@@ -105,10 +105,10 @@ describe("bbsSignature", () => {
         nonce: stringToBytes("bad"),
       };
 
-      expect(verifyProof(request).verified).toBeFalsy();
+      expect((await verifyProof(request)).verified).toBeFalsy();
     });
 
-    it("should not verify with a message that wasn't signed", () => {
+    it("should not verify with a message that wasn't signed", async () => {
       // Expects messages to be ["Message1", "Message2", "Message3", "Message4"];
       const messages = [
         stringToBytes("BadMessage1"),
@@ -129,11 +129,11 @@ describe("bbsSignature", () => {
         messages,
         nonce: stringToBytes("0123456789"),
       };
-      expect(verifyProof(request).verified).toBeFalsy();
+      expect((await verifyProof(request)).verified).toBeFalsy();
     });
   });
 
-  it("should not verify with revealed message that was supposed to be hidden", () => {
+  it("should not verify with revealed message that was supposed to be hidden", async () => {
     const messages = [
       stringToBytes("Message1"),
       stringToBytes("Message2"),
@@ -155,7 +155,7 @@ describe("bbsSignature", () => {
       revealed: [0],
       nonce,
     };
-    const proof = createProof(proofRequest);
+    const proof = await createProof(proofRequest);
 
     let proofMessages = [stringToBytes("BadMessage9")];
     let request = {
@@ -167,7 +167,7 @@ describe("bbsSignature", () => {
       revealed: [0],
     };
 
-    expect(verifyProof(request).verified).toBeFalsy();
+    expect((await verifyProof(request)).verified).toBeFalsy();
 
     proofMessages = [stringToBytes("Message1")];
     request = {
@@ -178,11 +178,11 @@ describe("bbsSignature", () => {
       nonce,
       revealed: [0],
     };
-    expect(verifyProof(request).verified).toBeTruthy();
+    expect((await verifyProof(request)).verified).toBeTruthy();
   });
 
   describe("blsVerifyProof", () => {
-    it("should verify proof with all messages revealed from single message signature", () => {
+    it("should verify proof with all messages revealed from single message signature", async () => {
       const messages = [stringToBytes("KnYAbm0fw3mlUA==")];
       const blsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb"
@@ -198,10 +198,10 @@ describe("bbsSignature", () => {
         nonce: stringToBytes("4OS3nji2HNReo3QPHrdlxjOf8gc="),
       };
 
-      expect(blsVerifyProof(request).verified).toBeTruthy();
+      expect((await blsVerifyProof(request)).verified).toBeTruthy();
     });
 
-    it("should verify proof with all messages revealed from multi message signature", () => {
+    it("should verify proof with all messages revealed from multi message signature", async () => {
       const messages = [
         stringToBytes("ODLpUKee6nyz7g=="),
         stringToBytes("v2zteJajIyIh5Q=="),
@@ -221,10 +221,10 @@ describe("bbsSignature", () => {
         nonce: stringToBytes("ujMevaaq2n7Cg3ZLzXktqT/WRgM="),
       };
 
-      expect(blsVerifyProof(request).verified).toBeTruthy();
+      expect((await blsVerifyProof(request)).verified).toBeTruthy();
     });
 
-    it("should verify proof with one message revealed from multi-message signature", () => {
+    it("should verify proof with one message revealed from multi-message signature", async () => {
       const messages = [
         stringToBytes("8NhsJO/MKxO74A=="),
         stringToBytes("0noLBcl29ASJ2w=="),
@@ -246,10 +246,10 @@ describe("bbsSignature", () => {
         nonce: stringToBytes("I03DvFXcpVdOPuOiyXgcBf4voAA="),
       };
 
-      expect(blsVerifyProof(request).verified).toBeTruthy();
+      expect((await blsVerifyProof(request)).verified).toBeTruthy();
     });
 
-    it("should not verify with bad nonce", () => {
+    it("should not verify with bad nonce", async () => {
       const messages = [stringToBytes("KnYAbm0fw3mlUA==")];
       const blsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb"
@@ -265,7 +265,7 @@ describe("bbsSignature", () => {
         nonce: stringToBytes("bad"),
       };
 
-      expect(blsVerifyProof(request).verified).toBeFalsy();
+      expect((await blsVerifyProof(request)).verified).toBeFalsy();
     });
   });
 });

--- a/tests/bbs_plus.rs
+++ b/tests/bbs_plus.rs
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 - MATTR Limited
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 //! Test suite for the Web and headless browsers.
 
 #![cfg(target_arch = "wasm32")]
@@ -12,7 +25,7 @@ wasm_bindgen_test_configure!(run_in_browser);
 
 #[allow(non_snake_case)]
 #[wasm_bindgen_test]
-pub fn bbs_sign_tests() {
+pub async fn bbs_sign_tests() {
     let (pk, sk) = generate(1).unwrap();
     let messages = vec![b"Message1".to_vec()];
     let request = BbsSignRequest {
@@ -24,7 +37,7 @@ pub fn bbs_sign_tests() {
         messages,
     };
     let js_value = serde_wasm_bindgen::to_value(&request).unwrap();
-    let s_res = bbs_sign(js_value);
+    let s_res = bbs_sign(js_value).await;
     assert!(s_res.is_ok());
     let s = s_res.unwrap();
     assert!(s.is_object());
@@ -48,7 +61,7 @@ pub fn bbs_sign_tests() {
         messages,
     };
     let js_value = serde_wasm_bindgen::to_value(&request).unwrap();
-    let s_res = bbs_sign(js_value);
+    let s_res = bbs_sign(js_value).await;
     assert!(s_res.is_ok());
     let s = s_res.unwrap();
     assert!(s.is_object());
@@ -58,7 +71,7 @@ pub fn bbs_sign_tests() {
 
 #[allow(non_snake_case)]
 #[wasm_bindgen_test]
-pub fn bbs_verify_tests() {
+pub async fn bbs_verify_tests() {
     let (pk, sk) = generate(1).unwrap();
     let messages = vec![SignatureMessage::hash(b"Message1")];
     let signature = Signature::new(messages.as_slice(), &sk, &pk).unwrap();
@@ -69,7 +82,7 @@ pub fn bbs_verify_tests() {
     };
     let js_value = serde_wasm_bindgen::to_value(&request).unwrap();
 
-    let result = bbs_verify(js_value);
+    let result = bbs_verify(js_value).await;
     assert!(result.is_ok());
     let result = result.unwrap();
     assert!(result.is_truthy());
@@ -79,7 +92,7 @@ pub fn bbs_verify_tests() {
         messages: vec![b"BadMessage".to_vec()],
     };
     let js_value = serde_wasm_bindgen::to_value(&request).unwrap();
-    let result = bbs_verify(js_value);
+    let result = bbs_verify(js_value).await;
     assert!(result.is_ok());
     let result = result.unwrap();
     let r: BbsVerifyResponse = serde_wasm_bindgen::from_value(result).unwrap();
@@ -88,7 +101,7 @@ pub fn bbs_verify_tests() {
 
 #[allow(non_snake_case)]
 #[wasm_bindgen_test]
-pub fn bbs_blind_sign_tests() {
+pub async fn bbs_blind_sign_tests() {
     let (pk, _) = generate(3).unwrap();
     let messages = vec![b"Message1".to_vec()];
     let request = BlindSignatureContextRequest {
@@ -98,7 +111,7 @@ pub fn bbs_blind_sign_tests() {
         nonce: b"dummy nonce".to_vec(),
     };
     let js_value = serde_wasm_bindgen::to_value(&request).unwrap();
-    let result = bbs_blind_signature_commitment(js_value);
+    let result = bbs_blind_signature_commitment(js_value).await;
     assert!(result.is_ok());
     let result: BlindSignatureContextResponse = result.unwrap().try_into().unwrap();
 
@@ -114,7 +127,7 @@ pub fn bbs_blind_sign_tests() {
     };
     let js_value = serde_wasm_bindgen::to_value(&request).unwrap();
 
-    let res = bbs_verify_blind_signature_proof(js_value);
+    let res = bbs_verify_blind_signature_proof(js_value).await;
     assert!(res.is_ok());
     let res = res.unwrap();
     assert!(res.is_truthy());
@@ -129,7 +142,7 @@ pub fn bbs_blind_sign_tests() {
     };
     let js_value = serde_wasm_bindgen::to_value(&request).unwrap();
 
-    let res = bbs_verify_blind_signature_proof(js_value);
+    let res = bbs_verify_blind_signature_proof(js_value).await;
     assert!(res.is_ok());
     let res = res.unwrap();
     assert!(res.is_falsy());

--- a/tests/bls12381.rs
+++ b/tests/bls12381.rs
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 - MATTR Limited
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 //! Test suite for the Web and headless browsers.
 
 #![cfg(target_arch = "wasm32")]
@@ -11,7 +24,7 @@ wasm_bindgen_test_configure!(run_in_browser);
 
 #[allow(non_snake_case)]
 #[wasm_bindgen_test]
-fn bls_public_key_to_bbs_key_test() {
+async fn bls_public_key_to_bbs_key_test() {
     let (dpk, _) = DeterministicPublicKey::new(None);
     let request = Bls12381ToBbsRequest {
         keyPair: BlsKeyPair {
@@ -21,7 +34,7 @@ fn bls_public_key_to_bbs_key_test() {
         messageCount: 5,
     };
     let js_value = serde_wasm_bindgen::to_value(&request).unwrap();
-    let bbs_res = bls_to_bbs_key(js_value);
+    let bbs_res = bls_to_bbs_key(js_value).await;
     assert!(bbs_res.is_ok());
     let bbs = bbs_res.unwrap();
     assert!(bbs.is_object());
@@ -33,7 +46,7 @@ fn bls_public_key_to_bbs_key_test() {
 
 #[allow(non_snake_case)]
 #[wasm_bindgen_test]
-fn bls_secret_key_to_bbs_key_test() {
+async fn bls_secret_key_to_bbs_key_test() {
     let (_, sk) = DeterministicPublicKey::new(None);
     let request = Bls12381ToBbsRequest {
         keyPair: BlsKeyPair {
@@ -43,7 +56,7 @@ fn bls_secret_key_to_bbs_key_test() {
         messageCount: 5,
     };
     let js_value = serde_wasm_bindgen::to_value(&request).unwrap();
-    let bbs_res = bls_to_bbs_key(js_value);
+    let bbs_res = bls_to_bbs_key(js_value).await;
     assert!(bbs_res.is_ok());
     let bbs = bbs_res.unwrap();
     assert!(bbs.is_object());
@@ -55,8 +68,8 @@ fn bls_secret_key_to_bbs_key_test() {
 
 #[allow(non_snake_case)]
 #[wasm_bindgen_test]
-fn bls_generate_key_from_seed_test() {
-    let key = bls_generate_g2_key(Some(vec![0u8; 16]));
+async fn bls_generate_key_from_seed_test() {
+    let key = bls_generate_g2_key(Some(vec![0u8; 16])).await.unwrap();
 
     assert!(key.is_object());
     let obj = js_sys::Object::try_from(&key);
@@ -98,8 +111,8 @@ fn bls_generate_key_from_seed_test() {
 
 #[allow(non_snake_case)]
 #[wasm_bindgen_test]
-fn bls_generate_key_test() {
-    let key = bls_generate_g2_key(None);
+async fn bls_generate_key_test() {
+    let key = bls_generate_g2_key(None).await.unwrap();
 
     assert!(key.is_object());
     let obj = js_sys::Object::try_from(&key);

--- a/tests/bls12381.spec.ts
+++ b/tests/bls12381.spec.ts
@@ -34,8 +34,8 @@ describe("bls12381", () => {
       publicKeyLength: DEFAULT_BLS12381_G2_PUBLIC_KEY_LENGTH,
     },
   ].forEach((value) => {
-    it(`should be able to generate a key pair in ${value.field} field`, () => {
-      const result = value.generateKeyFn();
+    it(`should be able to generate a key pair in ${value.field} field`, async () => {
+      const result = await value.generateKeyFn();
       expect(result).toBeDefined();
       expect(result.publicKey).toBeDefined();
       expect(result.secretKey).toBeDefined();
@@ -58,9 +58,9 @@ describe("bls12381", () => {
       publicKeyLength: DEFAULT_BLS12381_G2_PUBLIC_KEY_LENGTH,
     },
   ].forEach((value) => {
-    it(`should be able to generate a key pairs in ${value.field} field without seed which are random`, () => {
-      const keyPair1 = value.generateKeyFn();
-      const keyPair2 = value.generateKeyFn();
+    it(`should be able to generate a key pairs in ${value.field} field without seed which are random`, async () => {
+      const keyPair1 = await value.generateKeyFn();
+      const keyPair2 = await value.generateKeyFn();
       expect(keyPair1).toBeDefined();
       expect(keyPair2).toBeDefined();
       expect(
@@ -115,8 +115,8 @@ describe("bls12381", () => {
       ),
     },
   ].forEach((value) => {
-    it(`should be able to generate a key pair with a seed in ${value.field} field`, () => {
-      const result = value.generateKeyFn(value.seed);
+    it(`should be able to generate a key pair with a seed in ${value.field} field`, async () => {
+      const result = await value.generateKeyFn(value.seed);
       expect(result.publicKey).toBeDefined();
       expect(result.secretKey).toBeDefined();
       expect(result.secretKey?.length as number).toEqual(value.secretKeyLength);

--- a/tests/bls12381ToBbs.spec.ts
+++ b/tests/bls12381ToBbs.spec.ts
@@ -14,10 +14,10 @@
 import { generateBls12381G2KeyPair, bls12381toBbs, BlsKeyPair } from "../lib";
 
 describe("bls12381toBbs", () => {
-  it("should be able to convert bls12381 key pair to bbs key", () => {
-    const blsKeyPair = generateBls12381G2KeyPair();
+  it("should be able to convert bls12381 key pair to bbs key", async () => {
+    const blsKeyPair = await generateBls12381G2KeyPair();
     expect(blsKeyPair).toBeDefined();
-    const bbsKeyPair = bls12381toBbs({
+    const bbsKeyPair = await bls12381toBbs({
       keyPair: blsKeyPair,
       messageCount: 10,
     });
@@ -29,13 +29,13 @@ describe("bls12381toBbs", () => {
     expect(bbsKeyPair.secretKey).toBeInstanceOf(Uint8Array);
   });
 
-  it("should be able to convert bls12381 public key to bbs key", () => {
-    const blsKeyPair = generateBls12381G2KeyPair();
+  it("should be able to convert bls12381 public key to bbs key", async () => {
+    const blsKeyPair = await generateBls12381G2KeyPair();
     expect(blsKeyPair).toBeDefined();
     const blsPublicKey: BlsKeyPair = {
       publicKey: blsKeyPair.publicKey,
     };
-    const bbsKeyPair = bls12381toBbs({
+    const bbsKeyPair = await bls12381toBbs({
       keyPair: blsPublicKey,
       messageCount: 10,
     });
@@ -47,15 +47,15 @@ describe("bls12381toBbs", () => {
     expect(bbsKeyPair.publicKey).toBeInstanceOf(Uint8Array);
   });
 
-  it("should throw error when message count 0", () => {
-    const blsKeyPair = generateBls12381G2KeyPair();
+  it("should throw error when message count 0", async () => {
+    const blsKeyPair = await generateBls12381G2KeyPair();
     expect(blsKeyPair).toBeDefined();
 
-    expect(() =>
+    await expect(
       bls12381toBbs({
         keyPair: blsKeyPair,
         messageCount: 0,
       })
-    ).toThrowError("Failed to convert key");
+    ).rejects.toThrowError("Failed to convert key");
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -494,10 +494,10 @@
     mkdirp "^0.5.1"
     rimraf "^2.5.2"
 
-"@mattrglobal/node-bbs-signatures@0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@mattrglobal/node-bbs-signatures/-/node-bbs-signatures-0.10.0.tgz#6bdcdf135f8b101bf74f07207589104ef505db3d"
-  integrity sha512-i2sd61gXQJ0YJZ6JLUnKoQ8w+V39OOh5cdrYv0odnnF00H0a8y9JbSoDbzqEywFGol6oXk2ezFGI/ilU+1R7wQ==
+"@mattrglobal/node-bbs-signatures@0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@mattrglobal/node-bbs-signatures/-/node-bbs-signatures-0.11.0.tgz#c63ab8648a529cfe1dd855cc78a93f78ee27a9f4"
+  integrity sha512-V0wcY0ZewrPOiMOrL3wam0oYL1SLbF2ihgAM6JQvLrAKw1MckYiJ8T4vL+nOBs2hf1PA1TZI+USe5mqMWuVKTw==
   dependencies:
     neon-cli "0.4.0"
     node-pre-gyp "0.14.0"


### PR DESCRIPTION
## Description

Migrates the API to be async (promise) based

Also fixes #60 by using WebAssembly.instantiate

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

All API's will now return a promise wrapped result rather than the result directly.

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)