### PR TITLE
fix: verify proof bug

### DIFF
--- a/src/bbs_plus.rs
+++ b/src/bbs_plus.rs
@@ -316,9 +316,16 @@ pub async fn bbs_verify_proof(request: JsValue) -> Result<JsValue, JsValue> {
         verification_key: request.publicKey,
     };
 
+    let revealed_vec = proof_request
+        .revealed_messages
+        .iter()
+        .collect::<Vec<&usize>>();
     let mut revealed_messages = BTreeMap::new();
-    for i in &proof_request.revealed_messages {
-        revealed_messages.insert(*i, SignatureMessage::hash(&messages[*i]));
+    for i in 0..revealed_vec.len() {
+        revealed_messages.insert(
+            *revealed_vec[i],
+            SignatureMessage::hash(messages[i].clone()),
+        );
     }
 
     let signature_proof = SignatureProof {

--- a/src/bls12381.rs
+++ b/src/bls12381.rs
@@ -280,9 +280,16 @@ pub async fn bls_verify_proof(request: JsValue) -> Result<JsValue, JsValue> {
         verification_key: pk,
     };
 
+    let revealed_vec = proof_request
+        .revealed_messages
+        .iter()
+        .collect::<Vec<&usize>>();
     let mut revealed_messages = BTreeMap::new();
-    for i in &proof_request.revealed_messages {
-        revealed_messages.insert(*i, SignatureMessage::hash(&messages[*i]));
+    for i in 0..revealed_vec.len() {
+        revealed_messages.insert(
+            *revealed_vec[i],
+            SignatureMessage::hash(messages[i].clone()),
+        );
     }
 
     let signature_proof = SignatureProof {

--- a/tests/bbsSignature/verifyProof.bbsSignature.spec.ts
+++ b/tests/bbsSignature/verifyProof.bbsSignature.spec.ts
@@ -224,6 +224,31 @@ describe("bbsSignature", () => {
       expect((await blsVerifyProof(request)).verified).toBeTruthy();
     });
 
+    it("should verify proof with multiple messages revealed from multi-message signature", async () => {
+      const messages = [
+        stringToBytes("uiSKIfNoO2rMrA=="),
+        stringToBytes("lMoHHrFx0LxwAw=="),
+        stringToBytes("wdwqLVm9chMMnA=="),
+      ];
+      const blsPublicKey = base64Decode(
+        "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb"
+      );
+      const proof = base64Decode(
+        "AAMFkCuKmSKVB4QeCczJx4gBEtGoYY2ChhcNMYTbVa1L/vpcWmFYwUQHNN+n9TetMJygkJETUL30Zv+iYqplSMkdTBDe36TZKlCi+2+MaIhh66HsJT7lWcvpkxI3uC8SyDEutqVSIaVdsb1czpiQbxbjfo+Cg5nPw3qKpeSb7kGY3dMRRMd/Ug0YnGEN9eUqsWt/AAAAdKeTj+pJJiAVX9FuWIv7c4GVYEfzwyD7WXGBIWdrKIZdRLOIn+NGUmIdutzRr9ISiQAAAAIR2WRLfTY/mnmo4oz9iOgQwpoELlkXpU5Gx0sLMMBbxgqjg9aktKyVy6HXuWLafe1YyoV7acXWRbvfwPMoI/dwuDBAJQ30CHN+GD/ZkGvEq5VfogWE1gttKmwzwDatvaYuc16aC4BkdJ6qu+H9Z4+rAAAAA12Q0JuR4V606bCaqYLw+JzSkoyGGIviZnBezqR4pINTUPXBQQQ57cm8l5ldBM0uM6220n40hrc6kVKgJpUcIC8N68lTkdo/RGTF4lYdwYz7L7lZwmaSSLuGi0J+n7mbUA=="
+      );
+
+      const revealedMessages = [messages[0], messages[2]];
+
+      const request: BbsVerifyProofRequest = {
+        proof,
+        publicKey: blsPublicKey,
+        messages: revealedMessages,
+        nonce: base64Decode("csBYAufrvE1zkg=="),
+      };
+      const result = await blsVerifyProof(request);
+      expect(result.verified).toBeTruthy();
+    });
+
     it("should verify proof with one message revealed from multi-message signature", async () => {
       const messages = [
         stringToBytes("8NhsJO/MKxO74A=="),


### PR DESCRIPTION
## Description

Found due to [this upstream bug report](https://github.com/mattrglobal/jsonld-signatures-bbs/issues/119), the logic around determining which messages were revealed from the proof based on the proof value was resulting in an index out of bounds issue in certain circumstances.

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

See above

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)