### PR TITLE
build: update wasm loading logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "module": "lib/index.web.js",
-  "browser": {
-    "index.js": "lib/index.web.js"
-  },
   "repository": "https://github.com/mattrglobal/bbs-signatures",
   "files": [
     "lib/*"
@@ -26,8 +23,8 @@
     "install": "./scripts/install-dependencies.sh",
     "uninstall": "rm -rf node_modules && yarn clean",
     "clean": "rm -rf target && rm -rf dist",
-    "build": "./scripts/build-package.sh DEBUG && yarn rollup &&rollup ./lib/wasm.js --file ./lib/wasm_cjs.js --format cjs",
-    "build:release": "./scripts/build-package.sh RELEASE && yarn rollup &&rollup ./lib/wasm.js --file ./lib/wasm_cjs.js --format cjs",
+    "build": "./scripts/build-package.sh DEBUG",
+    "build:release": "./scripts/build-package.sh RELEASE",
     "test": "yarn test:browser && yarn test:node && yarn test:wasm",
     "test:browser": "./scripts/test-browser.sh",
     "test:node": "BBS_SIGNATURES_MODE=\"NODE_JS_MODULE\" yarn jest",

--- a/scripts/pack-wasm-base64.js
+++ b/scripts/pack-wasm-base64.js
@@ -1,0 +1,12 @@
+"use strict";
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+const fs = require("fs");
+const buffer = fs.readFileSync("./lib/wasm_bg.wasm");
+
+fs.writeFileSync(
+  "./lib/wasm_bs64.js",
+  `
+module.exports = Buffer.from('${buffer.toString("base64")}', 'base64');
+`
+);

--- a/src/js/index.web.js
+++ b/src/js/index.web.js
@@ -38,7 +38,7 @@ const throwErrorOnRejectedPromise = async (promise, errorMessage) => {
 let initializedModule;
 const initialize = async () => {
   if (!initializedModule) {
-    initializedModule = await init();
+    initializedModule = await init(new URL("wasm_bg.wasm", import.meta.url));
   }
 };
 

--- a/src/js/wasm_module.js
+++ b/src/js/wasm_module.js
@@ -12,8 +12,6 @@
  * limitations under the License.
  */
 
-const { nodejs } = require("./util");
-
 // Inject the RNG source when in NodeJS environments
 const { randomBytes } = require("@stablelib/random");
 
@@ -48,15 +46,7 @@ const throwErrorOnRejectedPromise = async (promise, errorMessage) => {
 let initializedModule;
 const initialize = async () => {
   if (!initializedModule) {
-    if (nodejs) {
-      // Fetch the wasm and load the module manually
-      const path = require("path").join(__dirname, "wasm_bg.wasm");
-      const bytes = require("fs").readFileSync(path);
-      const wasmModule = new WebAssembly.Module(bytes);
-      initializedModule = await wasm.default(wasmModule);
-    } else {
-      initializedModule = await wasm.default();
-    }
+    initializedModule = await wasm.default();
   }
 };
 


### PR DESCRIPTION
## Description

When consuming the default CJS version upstream due to how the web based wasm-pack version loads the WASM by default there are issues compiling with web-pack. So instead this PR shifts the CJS version to using a base64 encoded version of the wasm which is isomorphic to both node and browser.

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

See above

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)