### PR TITLE
Strict check for given messages count and originally revealed

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     }
   },
   "optionalDependencies": {
-    "@mattrglobal/node-bbs-signatures": "0.12.0"
+    "@mattrglobal/node-bbs-signatures": "^0.13.0"
   },
   "dependencies": {
     "@stablelib/random": "1.0.0"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     }
   },
   "optionalDependencies": {
-    "@mattrglobal/node-bbs-signatures": "^0.13.0"
+    "@mattrglobal/node-bbs-signatures": "0.13.0"
   },
   "dependencies": {
     "@stablelib/random": "1.0.0"

--- a/src/bls12381.rs
+++ b/src/bls12381.rs
@@ -284,6 +284,17 @@ pub async fn bls_verify_proof(request: JsValue) -> Result<JsValue, JsValue> {
     let pk = request.publicKey.to_public_key(message_count)?;
     let messages = request.messages.clone();
     let (revealed, proof) = request.proof.unwrap();
+    if messages.len() != revealed.len() {
+        return Ok(serde_wasm_bindgen::to_value(&BbsVerifyResponse {
+            verified: false,
+            error: Some(format!(
+                "Given messages count ({}) is different from revealed messages count ({}) for this proof",
+                messages.len(),
+                revealed.len()
+            )),
+        })
+            .unwrap())
+    }
     let proof_request = ProofRequest {
         revealed_messages: revealed,
         verification_key: pk,

--- a/tests/bbsSignature/verifyProof.bbsSignature.spec.ts
+++ b/tests/bbsSignature/verifyProof.bbsSignature.spec.ts
@@ -297,6 +297,31 @@ describe("bbsSignature", () => {
       expect((await blsVerifyProof(request)).verified).toBeTruthy();
     });
 
+    it("should not verify with more given messages than revealed", async () => {
+      const messages = [
+        stringToBytes("8NhsJO/MKxO74A=="),
+        stringToBytes("0noLBcl29ASJ2w=="),
+        stringToBytes("eMPpY348vqGDNA=="),
+      ];
+      const blsPublicKey = base64Decode(
+        "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb"
+      );
+      const proof = base64Decode(
+        "AAMBjl1W6j/1y/M3V4OIluw3BSTvgKCYRh+2SSeNNfDSZzKqNJAlQMGfHvBzpFQN55MZscHwEmMM6yWK2dqKGVhecvkwUvOIogpMFTbf3ikMor375ddSB3MAuHvgmlZKdLz7iwbxoCrf4+zfDvYeeLF6QR1uMdUa7v50ix2ZeSllsmOk5NxrEVMZXJ/+SDfASgTZAAAAdJeaUx4qwv5W72EKCDSBIYfxwlj28IGx0TnDm0E1y10n3hE0SIKYzgqqE81SPV9jfwAAAAIdssV4x73UeqxXmgQJSMO4XKDiiyxprlrpyz+1tINi7QbUABSCe4T1pdYOS0miYLDwzy2/zS2uuJ12yfqj6S1hl0U/uNbr03t8xypruPQhYreQGanMpFCnZquOJ9CYTGSPwMl1Hlva5hW0Jcrwugn1AAAABDLHtpcxsutFpn2EiPTYZMEeNnVr2x5AggpCAuLfd0+JBKEEwHKANSeajnWKBZ0YkZ/MpXkpU3ThRYWijpb6EsE4QJzkzSzKt5ZQCXsRkFLg/gWZIAUzKEjk3G2ELrFHlR9AedW1eANiHF/4ZuQPAtlRYg+mxeiEp87/xoLdq+OA"
+      );
+
+      const revealedMessages = messages.slice(0, 2);
+
+      const request: BbsVerifyProofRequest = {
+        proof,
+        publicKey: blsPublicKey,
+        messages: revealedMessages,
+        nonce: stringToBytes("I03DvFXcpVdOPuOiyXgcBf4voAA="),
+      };
+
+      expect((await blsVerifyProof(request)).verified).toBeFalsy();
+    });
+
     it("should not verify with malformed proof", async () => {
       const messages = [
         stringToBytes("Message1"),

--- a/yarn.lock
+++ b/yarn.lock
@@ -494,10 +494,10 @@
     mkdirp "^0.5.1"
     rimraf "^2.5.2"
 
-"@mattrglobal/node-bbs-signatures@0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@mattrglobal/node-bbs-signatures/-/node-bbs-signatures-0.12.0.tgz#5159f54dd7930b04589b88bfff35fa1a62b9d36e"
-  integrity sha512-ykkxezgCnET1iv2J4QSe0dFLlXknPvyAgi17WO9FJ7hRXTtZbCnUCyM4b3GWZKhiM7ZbnYX7rAuxfVwq+30dgA==
+"@mattrglobal/node-bbs-signatures@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@mattrglobal/node-bbs-signatures/-/node-bbs-signatures-0.13.0.tgz#3e431b915325d4b139706f8b26fd84b27c192a29"
+  integrity sha512-S2wOwDCQYxdjSEjVfcbP3bTq4ZMKeRw/wvBhWRff8CEwuH5u3Qiul+azwDGSesvve1DDceaEhXWiGkXeZTojfQ==
   dependencies:
     neon-cli "0.8.2"
     node-pre-gyp "0.17.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -494,7 +494,7 @@
     mkdirp "^0.5.1"
     rimraf "^2.5.2"
 
-"@mattrglobal/node-bbs-signatures@^0.13.0":
+"@mattrglobal/node-bbs-signatures@0.13.0":
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/@mattrglobal/node-bbs-signatures/-/node-bbs-signatures-0.13.0.tgz#3e431b915325d4b139706f8b26fd84b27c192a29"
   integrity sha512-S2wOwDCQYxdjSEjVfcbP3bTq4ZMKeRw/wvBhWRff8CEwuH5u3Qiul+azwDGSesvve1DDceaEhXWiGkXeZTojfQ==


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
-->

## Description

<!--- Describe your changes in detail -->

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../CONTRIBUTING.md)** document.

## Motivation and Context
The main point of this PR is to restrict providing more messages to the `blsVerifyProof` than it was revealed originally. For now it is possible to provide all revealed + signed messages in the right order and then add to the messages array some additional, not signed, not revealed messages and receive a successful response `result.verified === true`. More details in the [issue](https://github.com/mattrglobal/node-bbs-signatures/issues/174)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
