### PR TITLE
chore: pin codecov github action version

### DIFF
--- a/.github/workflows/push-master.yaml
+++ b/.github/workflows/push-master.yaml
@@ -32,6 +32,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
       - name: Report Coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192 # pin@1.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
As part of the preparation for the Trail of Bits audit we are pinning all non GitHub owned actions.

## Description

Pinning the version to 1.5.2 with this [commit](https://github.com/codecov/codecov-action/commit/29386c70ef20e286228c72b668a06fd0e8399192)

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

[DXM-854](https://mattrglobal.atlassian.net/jira/software/c/projects/DXM/boards/49?modal=detail&selectedIssue=DXM-854)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)