### PR TITLE
feat(types): convert exports to explicit type exports

### DIFF
--- a/src/js/types/index.ts
+++ b/src/js/types/index.ts
@@ -11,17 +11,21 @@
  * limitations under the License.
  */
 
-export { BbsBlindSignContext } from "./BbsBlindSignContext";
-export { BbsBlindSignContextRequest } from "./BbsBlindSignContextRequest";
-export { BbsBlindSignRequest } from "./BbsBlindSignRequest";
-export { BbsCreateProofRequest } from "./BbsCreateProofRequest";
-export { BbsKeyPair } from "./BbsKeyPair";
-export { BbsSignRequest } from "./BbsSignRequest";
-export { BbsVerifyBlindSignContextRequest } from "./BbsVerifyBlindSignContextRequest";
-export { BbsVerifyProofRequest } from "./BbsVerifyProofRequest";
-export { BbsVerifyRequest } from "./BbsVerifyRequest";
-export { BlsKeyPair, DEFAULT_BLS12381_PRIVATE_KEY_LENGTH, DEFAULT_BLS12381_PUBLIC_KEY_LENGTH } from "./BlsKeyPair";
-export { Bls12381ToBbsRequest } from "./Bls12381ToBbsRequest";
-export { BlsBbsSignRequest } from "./BlsBbsSignRequest";
-export { BlsBbsVerifyRequest } from "./BlsBbsVerifyRequest";
-export { BbsVerifyResult } from "./BbsVerifyResult";
+export type { BbsBlindSignContext } from "./BbsBlindSignContext";
+export type { BbsBlindSignContextRequest } from "./BbsBlindSignContextRequest";
+export type { BbsBlindSignRequest } from "./BbsBlindSignRequest";
+export type { BbsCreateProofRequest } from "./BbsCreateProofRequest";
+export type { BbsKeyPair } from "./BbsKeyPair";
+export type { BbsSignRequest } from "./BbsSignRequest";
+export type { BbsVerifyBlindSignContextRequest } from "./BbsVerifyBlindSignContextRequest";
+export type { BbsVerifyProofRequest } from "./BbsVerifyProofRequest";
+export type { BbsVerifyRequest } from "./BbsVerifyRequest";
+export {
+  DEFAULT_BLS12381_PRIVATE_KEY_LENGTH,
+  DEFAULT_BLS12381_PUBLIC_KEY_LENGTH,
+} from "./BlsKeyPair";
+export type { BlsKeyPair } from "./BlsKeyPair";
+export type { Bls12381ToBbsRequest } from "./Bls12381ToBbsRequest";
+export type { BlsBbsSignRequest } from "./BlsBbsSignRequest";
+export type { BlsBbsVerifyRequest } from "./BlsBbsVerifyRequest";
+export type { BbsVerifyResult } from "./BbsVerifyResult";


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
-->

## Description

<!--- Describe your changes in detail -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Types cannot be re-exported when using the --isolatedModules TypeScript compiler flag. For some transpilers (Babel for example) this flag is mandatory, making it impossible to add this package.

TypeScript has a [Type-Only Imports and Export](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export) feature, which addresses this issue. This PR converts the type exports to explicit types.

Closes https://github.com/mattrglobal/bbs-signatures/issues/69

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)