### PR TITLE
build(workflows): bump node from 16 to 18

### DIFF
--- a/.github/workflows/any-pr.yaml
+++ b/.github/workflows/any-pr.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v1
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v1
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/push-master.yaml
+++ b/.github/workflows/push-master.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/push-release.yaml
+++ b/.github/workflows/push-release.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lib": "lib"
   },
   "engines": {
-    "node": ">=14"
+    "node": "=16 || >=18"
   },
   "scripts": {
     "install": "./scripts/install-dependencies.sh",


### PR DESCRIPTION
## Description

Updating node from 16 to 18 on workflows since 16 reached end-of-life

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

16 reached end-of-life so we should start dropping support

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)