### PR TITLE
feat: add node 18.x support

### DIFF
--- a/.github/workflows/any-pr.yaml
+++ b/.github/workflows/any-pr.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v1
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/any-pr.yaml
+++ b/.github/workflows/any-pr.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/any-pr.yaml
+++ b/.github/workflows/any-pr.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v1
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/push-master.yaml
+++ b/.github/workflows/push-master.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/push-master.yaml
+++ b/.github/workflows/push-master.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/push-master.yaml
+++ b/.github/workflows/push-master.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/push-release.yaml
+++ b/.github/workflows/push-release.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/push-release.yaml
+++ b/.github/workflows/push-release.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/push-release.yaml
+++ b/.github/workflows/push-release.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "lodash": "4.17.21"
   },
   "optionalDependencies": {
-    "@mattrglobal/node-bbs-signatures": "0.15.0"
+    "@mattrglobal/node-bbs-signatures": "0.17.0"
   },
   "dependencies": {
     "@stablelib/random": "1.0.0"

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -29,7 +29,6 @@ try {
     module.exports = require("@mattrglobal/node-bbs-signatures");
   }
 } catch (e) {
-  console.error(e);
   if (process.env.BBS_SIGNATURES_MODE === BBS_SIGNATURES_MODES.nodejs) {
     throw new Error(FAILED_TO_LOAD_NODE_MODULE);
   }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -28,7 +28,7 @@ try {
   if (!useWasm) {
     module.exports = require("@mattrglobal/node-bbs-signatures");
   }
-} catch (e) {
+} catch {
   if (process.env.BBS_SIGNATURES_MODE === BBS_SIGNATURES_MODES.nodejs) {
     throw new Error(FAILED_TO_LOAD_NODE_MODULE);
   }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -28,7 +28,8 @@ try {
   if (!useWasm) {
     module.exports = require("@mattrglobal/node-bbs-signatures");
   }
-} catch {
+} catch (e) {
+  console.error(e);
   if (process.env.BBS_SIGNATURES_MODE === BBS_SIGNATURES_MODES.nodejs) {
     throw new Error(FAILED_TO_LOAD_NODE_MODULE);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -746,10 +746,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@mapbox/node-pre-gyp@1.0.9":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.9.tgz#09a8781a3a036151cdebbe8719d6f8b25d4058bc"
-  integrity sha512-aDF3S3rK9Q2gey/WAttUlISduDItz5BU3306M9Eyv6/oS40aMprnopshtlKTykxRNIBEZuRMaZAnbrQ4QtKGyw==
+"@mapbox/node-pre-gyp@1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz#417db42b7f5323d79e93b34a6d7a2a12c0df43fa"
+  integrity sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==
   dependencies:
     detect-libc "^2.0.0"
     https-proxy-agent "^5.0.0"
@@ -761,12 +761,12 @@
     semver "^7.3.5"
     tar "^6.1.11"
 
-"@mattrglobal/node-bbs-signatures@0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@mattrglobal/node-bbs-signatures/-/node-bbs-signatures-0.15.0.tgz#acbe578253fa95d96141bd44cb65e75cd0b79c67"
-  integrity sha512-ipIwL1neAW/gwC0jg0aOFWiIipdvn6kq0Ta2ccSgc1pZUg6xPYj7dRMEaR6QJ9zV6qOBe7awETd1CoLunwwsLA==
+"@mattrglobal/node-bbs-signatures@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@mattrglobal/node-bbs-signatures/-/node-bbs-signatures-0.17.0.tgz#50d18ae45cd9b6a3ea5f17812cf6fb6c20baaf17"
+  integrity sha512-midEd1qGYfAKjILyIdEgyY7tbVwIFR7ozWli8AaxBaiDie2oBaj6O1A2rh/GCOKTpBZ3Thbi+CE0QZntWf+Xzg==
   dependencies:
-    "@mapbox/node-pre-gyp" "1.0.9"
+    "@mapbox/node-pre-gyp" "1.0.11"
     neon-cli "0.10.1"
 
 "@sinclair/typebox@^0.23.3":


### PR DESCRIPTION
## Description

1. Update to the latest `@mattrglobal/node-bbs-signatures`. This has the latest binaries that support Node 18.x
2. Add 18.x to the GitHub actions.

~Tests for the changes have been added (for bug fixes / features)~
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

Part of the organisation-wide upgrade to Node 18.x.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)