### PR TITLE
chore(release): publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# [2.0.0](https://github.com/mattrglobal/bbs-signatures/compare/v1.4.0...v2.0.0) (2024-09-19)
+
+### Build System
+
+- **deps:** bump @mattrglobal/node-bbs-signatures from 0.18.1 to 0.20.0 ([#187](https://github.com/mattrglobal/bbs-signatures/issues/187)) ([ac35f39](https://github.com/mattrglobal/bbs-signatures/commit/ac35f39afe178e4e4fddb11c0e4016785ab49994))
+
+### Features
+
+- adds node 20.x and 22.x support ([ac35f39](https://github.com/mattrglobal/bbs-signatures/commit/ac35f39afe178e4e4fddb11c0e4016785ab49994))
+
+### BREAKING CHANGES
+
+- removes node 16.x support ([ac35f39](https://github.com/mattrglobal/bbs-signatures/commit/ac35f39afe178e4e4fddb11c0e4016785ab49994))
+
 # [1.4.0](https://github.com/mattrglobal/bbs-signatures/compare/v1.3.1...v1.4.0) (2024-06-18)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattrglobal/bbs-signatures",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "author": "MATTR",
   "license": "Apache-2.0",
   "private": false,


### PR DESCRIPTION
## Description

Updates @mattrglobal/node-bbs-signatures from 0.18.1 to 0.20.0 to add support for Node 20.x and 22.x

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

Add node 20.x and 22.x support 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)